### PR TITLE
Update main.R

### DIFF
--- a/R/main.R
+++ b/R/main.R
@@ -72,7 +72,7 @@ if (multiomic) {
 
 # slim down signature matrix and df based on intersecting genes
 if (multiomic) {
-  for (s in 1:length(ref)) ref[[s]] <- ref[[s]][intersect(ref[[s]], unique(c(rownames(df1),rownames(df2))))]
+  for (s in 1:length(ref)) ref[[s]] <- intersect(ref[[s]], unique(c(rownames(df1),rownames(df2))))
   df1 <- as.data.frame(df1[intersect(rownames(df1),unique(unlist(ref))),])
   df2 <- as.data.frame(df2[intersect(rownames(df2),unique(unlist(ref))),])
   df2<-df2[,match(colnames(df1),colnames(df2))] # match samples in df2 to that of df1

--- a/R/main.R
+++ b/R/main.R
@@ -72,7 +72,7 @@ if (multiomic) {
 
 # slim down signature matrix and df based on intersecting genes
 if (multiomic) {
-  for (s in 1:length(ref)) ref[[s]] <- intersect(ref[[s]], unique(c(rownames(df1),rownames(df2))))
+  for (s in 1:length(ref)) ref[[s]] <- intersect(ref[[s]], intersect(rownames(df1),rownames(df2)))
   df1 <- as.data.frame(df1[intersect(rownames(df1),unique(unlist(ref))),])
   df2 <- as.data.frame(df2[intersect(rownames(df2),unique(unlist(ref))),])
   df2<-df2[,match(colnames(df1),colnames(df2))] # match samples in df2 to that of df1


### PR DESCRIPTION
when filtering the ref matrix to the multiomic intersect the assignment ref[[s]][intersect...] results in an NA matrix. This should be resolved by removing the ref[[s]][...] part and just keeping the intersect term

Furthermore, using the `intersect(ref[[s]], unique(rownames(df1), rowname(df2))` gives the intesect between the features in the reference matrix and the unity of df1 and df2 rownames (i.e. genes and proteins). Thus for the smaller data set (usually proteins) this results in an index matrix with a lot of NA (b/c many of the genes are not actually quantified in the proteome) and this laters throws an error when kicking of the MCMC "mean.initial". 

You can solve this by changing line 75 of main.R to 

`for (s in 1:length(ref)) ref[[s]] <- intersect(ref[[s]], intersect(rownames(df1),rownames(df2)))` which now subsets the reference matrix to the intersect of 1. the reference 2. the genes and 3. the proteins